### PR TITLE
Harden reactive builder cache handling

### DIFF
--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -1,0 +1,58 @@
+import pytest
+from framework.reactive import reactive, ReactiveBuilder, ReactiveEvent
+from framework.core import Pipeline, AbstractProcessor
+
+
+@reactive(provides=r".*", requires=[], cache=True)
+class BuildItem(ReactiveBuilder):
+    def build(self, context, target):
+        yield f"built-{target}"
+
+class Sink(AbstractProcessor):
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def process(self, context, event):
+        match event:
+            case ReactiveEvent(name="built", target=target, artifact=artifact):
+                self.events.append((target, artifact))
+
+
+def test_per_target_cache_isolated(tmp_path):
+    builder = BuildItem()
+    sink = Sink()
+    pipeline = Pipeline([builder, sink], strict_interest_inference=False, workspace=tmp_path)
+
+    pipeline.submit(ReactiveEvent(name="resolve", target="A"))
+    pipeline.submit(ReactiveEvent(name="resolve", target="B"))
+    pipeline.run()
+
+    assert sink.events == [("A", "built-A"), ("B", "built-B")]
+    # Ensure per-target subdirectories are used for persistence and contain SQLite archives.
+    assert (tmp_path / "A").is_dir()
+    assert (tmp_path / "B").is_dir()
+    assert (tmp_path / "A" / "BuildItem.sqlite").is_file()
+    assert (tmp_path / "B" / "BuildItem.sqlite").is_file()
+
+
+@reactive(provides="dict", requires=[], cache=True)
+class BuildDict(ReactiveBuilder):
+    def build(self, context, target):
+        yield {"result": target}
+
+
+def test_unhashable_artifacts(tmp_path):
+    builder = BuildDict()
+    sink = Sink()
+    pipeline = Pipeline([builder, sink], strict_interest_inference=False, workspace=tmp_path)
+
+    pipeline.submit(ReactiveEvent(name="resolve", target="dict"))
+    pipeline.run()
+    assert sink.events == [("dict", {"result": "dict"})]
+
+    # second run should replay from cache without crashing on unhashable artifacts
+    sink.events.clear()
+    pipeline.submit(ReactiveEvent(name="resolve", target="dict"))
+    pipeline.run()
+    assert sink.events == [("dict", {"result": "dict"})]


### PR DESCRIPTION
## Summary
- isolate persistent caches per target by storing archives in subdirectories and writing updates to disk
- replay cached artifacts without duplicates using DeepHash digests to support unhashable outputs
- cover per-target cache persistence and unhashable artifact caching with regression tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a9c507cc83298ce3547294cdbebf